### PR TITLE
Update scw-cli version to 2.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM scaleway/cli:v2.3.1 as upstream
+FROM scaleway/cli:v2.4.0 as upstream
 
 FROM alpine:3.8
 


### PR DESCRIPTION
Updates the version of the Scaleway CLI to 2.4.0